### PR TITLE
Add .coveralls.yml

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 after_success:
-  - ./node_modules/coveralls/bin/coveralls.js
+  - cat artifacts/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 language: node_js
 node_js:
   - "4.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+after_success:
+  - ./node_modules/coveralls/bin/coveralls.js
 language: node_js
 node_js:
   - "4.1"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ mocha-multi-reporters
 Generate multiple mocha reports in a single mocha execution.
 
 [![Build Status](https://travis-ci.org/stanleyhlng/mocha-multi-reporters.svg)](https://travis-ci.org/stanleyhlng/mocha-multi-reporters)
+[![Coverage Status](https://coveralls.io/repos/stanleyhlng/mocha-multi-reporters/badge.svg?branch=master&service=github)](https://coveralls.io/github/stanleyhlng/mocha-multi-reporters?branch=master)
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
+    "coveralls": "^2.11.6",
     "eslint": "^1.10.3",
     "eslint-config-defaults": "^7.1.1",
     "jenkins-mocha": "^2.5.0",
     "mocha": "^2.3.4",
+    "mocha-lcov-reporter": "^1.0.0",
     "pre-commit": "^1.1.2"
   },
   "keywords": [


### PR DESCRIPTION
Track code coverage using coveralls.io

doc: https://coveralls.zendesk.com/hc/en-us/articles/201769715-Javascript-Node