### PR TITLE
added unit test for exceptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "jenkins-mocha": "^2.6.0",
     "mocha": "^3.1.2",
     "mocha-lcov-reporter": "^1.2.0",
-    "pre-commit": "^1.1.3"
+    "pre-commit": "^1.1.3",
+    "sinon": "^1.17.6"
   },
   "keywords": [
     "mocha",

--- a/tests/lib/MultiReporters.test.js
+++ b/tests/lib/MultiReporters.test.js
@@ -2,6 +2,7 @@
 var _require = require('root-require');
 var expect = require('chai').expect;
 var Mocha = require('mocha');
+var sinon = require('sinon');
 var Suite = Mocha.Suite;
 var Runner = Mocha.Runner;
 var Test = Mocha.Test;
@@ -133,6 +134,32 @@ describe('lib/MultiReporters', function () {
                 });
             });
         });
+
+        describe('#exception', function () {
+            var err;
+            beforeEach(function () {
+                err = new Error('JSON.parse error!');
+                sinon.stub(JSON, 'parse').throws(err);
+            });
+
+            afterEach(function () {
+                JSON.parse.restore();
+            });
+
+            it('throw an exception in default options', function () {
+                expect(JSON.parse.callCount).to.equal(0);
+                expect(reporter.getDefaultOptions.bind(this)).to.throw(err);
+                expect(JSON.parse.threw()).to.equal(true);
+                expect(JSON.parse.callCount).to.equal(1);
+            });
+
+            it('throw an exception in custom options', function () {
+                expect(JSON.parse.callCount).to.equal(0);
+                expect(reporter.getCustomOptions.bind(this, options)).to.throw(err);
+                expect(JSON.parse.threw()).to.equal(true);
+                expect(JSON.parse.callCount).to.equal(1);
+            });
+        });        
     });
 
     describe('#test', function () {


### PR DESCRIPTION
This PR adds unit test for exception to increase overall code coverage from 87% to 92%.

```
➜  mocha-multi-reporters git:(exception-unit-test)  npm run test 

> mocha-multi-reporters@1.1.1 test /Users/stanleyn/Projects/stanleyhlng/github.com/mocha-multi-reporters
> JENKINS_MOCHA_COVERAGE=true jenkins-mocha --timeout 5000 tests/**/*.test.js*



  lib/MultiReporters
    #static
      #CONFIG_FILE
        ✓ equals to "../config.json"
    #instance
      #internal
        #options (reporters - single)
          ✓ return reporter options: "dot"
          ✓ return reporter options: "xunit"
        #options (reporters - multiple)
          ✓ return default options
          ✓ return custom options
          ✓ return resultant options by merging both default and custom options
      #external
        #options (external reporters - single)
          ✓ return reporter options: "dot"
      #exception
Error: JSON.parse error!
    at Context.<anonymous> (/Users/stanleyn/Projects/stanleyhlng/github.com/mocha-multi-reporters/tests/lib/MultiReporters.test.js:141:23)
    at callFn (/Users/stanleyn/Projects/stanleyhlng/github.com/mocha-multi-reporters/node_modules/jenkins-mocha/node_modules/mocha/lib/runnable.js:326:21)
    at Hook.Runnable.run (/Users/stanleyn/Projects/stanleyhlng/github.com/mocha-multi-reporters/node_modules/jenkins-mocha/node_modules/mocha/lib/runnable.js:319:7)
    at next (/Users/stanleyn/Projects/stanleyhlng/github.com/mocha-multi-reporters/node_modules/jenkins-mocha/node_modules/mocha/lib/runner.js:298:10)
    at Immediate.<anonymous> (/Users/stanleyn/Projects/stanleyhlng/github.com/mocha-multi-reporters/node_modules/jenkins-mocha/node_modules/mocha/lib/runner.js:320:5)
    at runCallback (timers.js:637:20)
    at tryOnImmediate (timers.js:610:5)
    at processImmediate [as _immediateCallback] (timers.js:582:5)
        ✓ throw an exception in default options
Error: JSON.parse error!
    at Context.<anonymous> (/Users/stanleyn/Projects/stanleyhlng/github.com/mocha-multi-reporters/tests/lib/MultiReporters.test.js:141:23)
    at callFn (/Users/stanleyn/Projects/stanleyhlng/github.com/mocha-multi-reporters/node_modules/jenkins-mocha/node_modules/mocha/lib/runnable.js:326:21)
    at Hook.Runnable.run (/Users/stanleyn/Projects/stanleyhlng/github.com/mocha-multi-reporters/node_modules/jenkins-mocha/node_modules/mocha/lib/runnable.js:319:7)
    at next (/Users/stanleyn/Projects/stanleyhlng/github.com/mocha-multi-reporters/node_modules/jenkins-mocha/node_modules/mocha/lib/runner.js:298:10)
    at Immediate.<anonymous> (/Users/stanleyn/Projects/stanleyhlng/github.com/mocha-multi-reporters/node_modules/jenkins-mocha/node_modules/mocha/lib/runner.js:320:5)
    at runCallback (timers.js:637:20)
    at tryOnImmediate (timers.js:610:5)
    at processImmediate [as _immediateCallback] (timers.js:582:5)
        ✓ throw an exception in custom options
    #test

#multi-reporter
  ✓ #test-1
  1) #test-2

  1 passing (6ms)
  1 failing

  1) #multi-reporter #test-2:

  Error
      at Context.<anonymous> (tests/lib/MultiReporters.test.js:196:30)



      ✓ should have 1 test failure

#multi-reporter
  - #test-1
  - #test-2

  0 passing (1ms)
  2 pending

      ✓ should have 1 test pending


  11 passing (191ms)

=============================================================================
Writing coverage object [/Users/stanleyn/Projects/stanleyhlng/github.com/mocha-multi-reporters/artifacts/coverage/coverage.json]
Writing coverage reports at [/Users/stanleyn/Projects/stanleyhlng/github.com/mocha-multi-reporters/artifacts/coverage]
=============================================================================

=============================== Coverage summary ===============================
Statements   : 92.65% ( 63/68 )
Branches     : 60% ( 6/10 )
Functions    : 100% ( 6/6 )
Lines        : 92.65% ( 63/68 )
================================================================================
```