### PR TITLE
Allow for custom options via Js file

### DIFF
--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -83,11 +83,15 @@ MultiReporters.prototype.getCustomOptions = function (options) {
         customOptionsFile = path.resolve(customOptionsFile);
         debug('options file (custom)', customOptionsFile);
 
-        customOptions = fs.readFileSync(customOptionsFile).toString();
-        debug('options (custom)', customOptions);
-
         try {
-            customOptions = JSON.parse(customOptions);
+          if ('.js' === path.extname(customOptionsFile)) {
+              customOptions = require(customOptionsFile);
+          }
+          else {
+              customOptions = JSON.parse(fs.readFileSync(customOptionsFile).toString());
+          }
+
+          debug('options (custom)', customOptions);
         }
         catch (e) {
             console.error(e);

--- a/tests/custom-external-config.js
+++ b/tests/custom-external-config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  "reporterEnabled": "mocha-junit-reporter",
+
+  "mochaJunitReporterReporterOptions": {
+    "id": "mocha-junit-reporter",
+    "mochaFile": "junit.xml"
+  }
+}

--- a/tests/lib/MultiReporters.test.js
+++ b/tests/lib/MultiReporters.test.js
@@ -110,26 +110,54 @@ describe('lib/MultiReporters', function () {
         });
 
         describe('#external', function () {
-            beforeEach(function () {
-                var mocha = new Mocha({
-                    reporter: MultiReporters
+            describe('json', function() {
+                beforeEach(function () {
+                    var mocha = new Mocha({
+                        reporter: MultiReporters
+                    });
+                    suite = new Suite('#external-multi-reporter', 'root');
+                    runner = new Runner(suite);
+                    options = {
+                        execute: false,
+                        reporterOptions: {
+                            configFile: 'tests/custom-external-config.json'
+                        }
+                    };
+                    reporter = new mocha._reporter(runner, options);
                 });
-                suite = new Suite('#external-multi-reporter', 'root');
-                runner = new Runner(suite);
-                options = {
-                    execute: false,
-                    reporterOptions: {
-                        configFile: 'tests/custom-external-config.json'
-                    }
-                };
-                reporter = new mocha._reporter(runner, options);
+
+                describe('#options (external reporters - single)', function () {
+                    it('return reporter options: "dot"', function () {
+                        expect(reporter.getReporterOptions(reporter.getOptions(options), 'mocha-junit-reporter')).to.be.deep.equal({
+                            id: 'mocha-junit-reporter',
+                            mochaFile: 'junit.xml'
+                        });
+                    });
+                });
             });
 
-            describe('#options (external reporters - single)', function () {
-                it('return reporter options: "dot"', function () {
-                    expect(reporter.getReporterOptions(reporter.getOptions(options), 'mocha-junit-reporter')).to.be.deep.equal({
-                        id: 'mocha-junit-reporter',
-                        mochaFile: 'junit.xml'
+            describe('js', function() {
+                beforeEach(function () {
+                    var mocha = new Mocha({
+                        reporter: MultiReporters
+                    });
+                    suite = new Suite('#external-multi-reporter', 'root');
+                    runner = new Runner(suite);
+                    options = {
+                        execute: false,
+                        reporterOptions: {
+                            configFile: 'tests/custom-external-config.js'
+                        }
+                    };
+                    reporter = new mocha._reporter(runner, options);
+                });
+
+                describe('#options (external reporters - single)', function () {
+                    it('return reporter options: "dot"', function () {
+                        expect(reporter.getReporterOptions(reporter.getOptions(options), 'mocha-junit-reporter')).to.be.deep.equal({
+                            id: 'mocha-junit-reporter',
+                            mochaFile: 'junit.xml'
+                        });
                     });
                 });
             });
@@ -138,6 +166,13 @@ describe('lib/MultiReporters', function () {
         describe('#exception', function () {
             var err;
             beforeEach(function () {
+              options = {
+                  execute: false,
+                  reporterOptions: {
+                      configFile: 'tests/custom-external-config.json'
+                  }
+              };
+
                 err = new Error('JSON.parse error!');
                 sinon.stub(JSON, 'parse').throws(err);
             });
@@ -159,7 +194,7 @@ describe('lib/MultiReporters', function () {
                 expect(JSON.parse.threw()).to.equal(true);
                 expect(JSON.parse.callCount).to.equal(1);
             });
-        });        
+        });
     });
 
     describe('#test', function () {


### PR DESCRIPTION
Allow for using a JS file (not just JSON) for specify reporter config. I need to be able to programmatically generate certain  paths in the reporter config, this is why I needed this.