### PR TITLE
Use unique test suite name and test case name

### DIFF
--- a/tests/lib/MultiReporters.test.js
+++ b/tests/lib/MultiReporters.test.js
@@ -110,6 +110,13 @@ describe('lib/MultiReporters', function () {
         });
 
         describe('#external', function () {
+            var checkReporterOptions = function (options) {
+                expect(reporter.getReporterOptions(reporter.getOptions(options), 'mocha-junit-reporter')).to.be.deep.equal({
+                    id: 'mocha-junit-reporter',
+                    mochaFile: 'junit.xml'
+                });
+            };
+
             describe('json', function() {
                 beforeEach(function () {
                     var mocha = new Mocha({
@@ -128,10 +135,7 @@ describe('lib/MultiReporters', function () {
 
                 describe('#options (external reporters w/ json - single)', function () {
                     it('json: return reporter options: "dot"', function () {
-                        expect(reporter.getReporterOptions(reporter.getOptions(options), 'mocha-junit-reporter')).to.be.deep.equal({
-                            id: 'mocha-junit-reporter',
-                            mochaFile: 'junit.xml'
-                        });
+                        checkReporterOptions(options);
                     });
                 });
             });
@@ -154,10 +158,7 @@ describe('lib/MultiReporters', function () {
 
                 describe('#options (external reporters w/ commonjs - single)', function () {
                     it('commonjs: return reporter options: "dot"', function () {
-                        expect(reporter.getReporterOptions(reporter.getOptions(options), 'mocha-junit-reporter')).to.be.deep.equal({
-                            id: 'mocha-junit-reporter',
-                            mochaFile: 'junit.xml'
-                        });
+                        checkReporterOptions(options);
                     });
                 });
             });

--- a/tests/lib/MultiReporters.test.js
+++ b/tests/lib/MultiReporters.test.js
@@ -126,8 +126,8 @@ describe('lib/MultiReporters', function () {
                     reporter = new mocha._reporter(runner, options);
                 });
 
-                describe('#options (external reporters - single)', function () {
-                    it('return reporter options: "dot"', function () {
+                describe('#options (external reporters w/ json - single)', function () {
+                    it('json: return reporter options: "dot"', function () {
                         expect(reporter.getReporterOptions(reporter.getOptions(options), 'mocha-junit-reporter')).to.be.deep.equal({
                             id: 'mocha-junit-reporter',
                             mochaFile: 'junit.xml'
@@ -152,8 +152,8 @@ describe('lib/MultiReporters', function () {
                     reporter = new mocha._reporter(runner, options);
                 });
 
-                describe('#options (external reporters - single)', function () {
-                    it('return reporter options: "dot"', function () {
+                describe('#options (external reporters w/ commonjs - single)', function () {
+                    it('commonjs: return reporter options: "dot"', function () {
                         expect(reporter.getReporterOptions(reporter.getOptions(options), 'mocha-junit-reporter')).to.be.deep.equal({
                             id: 'mocha-junit-reporter',
                             mochaFile: 'junit.xml'


### PR DESCRIPTION
This PR fixes the test suite and test case naming as `bithound` reports an error about duplicate function names.

https://www.bithound.io/github/stanleyhlng/mocha-multi-reporters/blob/df7ee94641782f6055583577822cbd9205249e00/tests/lib/MultiReporters.test.js#filter-duplicate