### PR TITLE
assume reporterOptions holds all options if configFile is !defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ ./node_modules/.bin/mocha --reporter mocha-multi-reporters
 </testsuite>
 ```
 
-### Advance
+### Advanced
 
 * Generate `spec` and `json` reports.
 
@@ -213,6 +213,27 @@ $ cat xunit-custom.xml
     </testcase>
   </testsuite>
 </testsuites>
+```
+
+* When calling Mocha programmatically
+
+Note that when Mocha is called programmatically, it is passed an options object when created.  This object is usually derived from a config file that your mocha test runner reads prior to instantiation.  This is the object that must contain a key `reporter` with a value of `mocha-multi-reporters` for this plugin to be used.  You can also pass the key `reporterOptions` with a value of any of the above listed config files (including the `reporterEnabled` subkey and any other plugin configuration information.)  This removes the requirement to have an intermediate configuration file specifically for the multireporter configuration.
+
+```js
+var mocha = new Mocha({
+      reporter: "mocha-multi-reporters",
+      timeout: config.testTimeout || 60000,
+      slow: config.slow || 10000,
+      reporterOptions: {
+          "reporterEnabled": "mocha-junit-reporter, tap",
+          "mochaJunitReporterReporterOptions": {
+              "mochaFile": "junit-custom.xml"
+          }
+      }
+    });
+    mocha.addFile(...)
+    mocha.run(...)
+
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ var mocha = new Mocha({
     mocha.run(...)
 
 ```
+Note that it will first check if reporterOptions contains a `configFile` key, and if it does, use that.  That key must not exist in the `reporterOptions` object in order to pass these values in directly.
 
 ## License
 

--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -97,7 +97,7 @@ MultiReporters.prototype.getCustomOptions = function (options) {
             console.error(e);
             throw e;
         }
-    }
+    } else { customOptions = _.get(options, "reporterOptions"); }
 
     return customOptions;
 };


### PR DESCRIPTION
This straight up fixes #31 , at least for all my use cases.

We already get the options from mocha, whichever way people may be calling it programmatically.  We don't work (well, it falls back to defaults) unless that options hash already contains a key pointing to a file to load its values from... so why not just use that as the entire reporter options config object, instead of having to require it from another file?