### PR TITLE
Support done methods

### DIFF
--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -3,7 +3,8 @@
 var _ = {
     get: require('lodash/get'),
     camelCase: require('lodash/camelCase'),
-    size: require('lodash/size')
+    size: require('lodash/size'),
+    after: require('lodash/after')
 };
 var debug = require('debug')('mocha:reporters:MultiReporters');
 var fs = require('fs');
@@ -69,12 +70,24 @@ util.inherits(MultiReporters, Base);
 MultiReporters.CONFIG_FILE = '../config.json';
 
 MultiReporters.prototype.done = function (failures, fn) {
-    if (_.size(this._reporters) === 0) return;
+    var numberOfReporters = _.size(this._reporters);
 
-    this._reporters.forEach(function(reporter) {
-        if (typeof reporter.done === 'function') {
-            reporter.done(failures, fn);
-        }
+    if (numberOfReporters === 0) {
+        console.error('Unable to invoke fn(failures) - no reporters were registered');
+        return;
+    }
+
+    var reportersWithDoneHandler = this._reporters.filter(function (reporter) {
+        return typeof reporter.done === 'function';
+    });
+
+    var done = _.after(_.size(reportersWithDoneHandler), function() {
+        console.log('DONE')
+        fn(failures);
+    });
+
+    reportersWithDoneHandler.forEach(function(reporter) {
+        reporter.done(failures, done);
     });
 };
 

--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -2,7 +2,8 @@
 
 var _ = {
     get: require('lodash/get'),
-    camelCase: require('lodash/camelCase')
+    camelCase: require('lodash/camelCase'),
+    size: require('lodash/size')
 };
 var debug = require('debug')('mocha:reporters:MultiReporters');
 var fs = require('fs');
@@ -15,12 +16,11 @@ var path = require('path');
 function MultiReporters(runner, options) {
     Base.call(this, runner);
 
-    var promises = [];
-
     if (_.get(options, 'execute', true)) {
+
         options = this.getOptions(options);
 
-        _.get(options, 'reporterEnabled', 'tap').split(',').map(
+        this._reporters = _.get(options, 'reporterEnabled', 'tap').split(',').map(
             function processReporterEnabled(name, index) {
                 debug(name, index);
 
@@ -50,7 +50,7 @@ function MultiReporters(runner, options) {
                 }
 
                 if (Reporter !== null) {
-                    new Reporter(
+                    return new Reporter(
                         runner, {
                             reporterOptions: reporterOptions
                         }
@@ -63,9 +63,20 @@ function MultiReporters(runner, options) {
         );
     }
 }
-util.inherits(MultiReporters, Base)
+
+util.inherits(MultiReporters, Base);
 
 MultiReporters.CONFIG_FILE = '../config.json';
+
+MultiReporters.prototype.done = function (failures, fn) {
+    if (_.size(this._reporters) === 0) return;
+
+    this._reporters.forEach(function(reporter) {
+        if (typeof reporter.done === 'function') {
+            reporter.done(failures, fn);
+        }
+    });
+};
 
 MultiReporters.prototype.getOptions = function (options) {
     debug('options', options);
@@ -97,7 +108,10 @@ MultiReporters.prototype.getCustomOptions = function (options) {
             console.error(e);
             throw e;
         }
-    } else { customOptions = _.get(options, "reporterOptions"); }
+    }
+    else {
+        customOptions = _.get(options, "reporterOptions");
+    }
 
     return customOptions;
 };

--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -82,7 +82,6 @@ MultiReporters.prototype.done = function (failures, fn) {
     });
 
     var done = _.after(_.size(reportersWithDoneHandler), function() {
-        console.log('DONE')
         fn(failures);
     });
 

--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -81,7 +81,13 @@ MultiReporters.prototype.done = function (failures, fn) {
         return typeof reporter.done === 'function';
     });
 
-    var done = _.after(_.size(reportersWithDoneHandler), function() {
+    var numberOfReportersWithDoneHandler = _.size(reportersWithDoneHandler);
+
+    if (numberOfReportersWithDoneHandler === 0) {
+        return fn(failures);
+    }
+
+    var done = _.after(numberOfReportersWithDoneHandler, function() {
         fn(failures);
     });
 

--- a/tests/lib/MultiReporters.test.js
+++ b/tests/lib/MultiReporters.test.js
@@ -87,6 +87,15 @@ describe('lib/MultiReporters', function () {
                     expect(fn.calledAfter(reporterC.done)).to.be.true;
                     expect(fn.firstCall.args).to.deep.equal([failures]);
                 });
+
+                it('executes fn(failures) when none of the registered reporters have a #done handlers', function () {
+                    reporter._reporters = [{}, {}];
+
+                    reporter.done(failures, fn);
+
+                    expect(fn.callCount).to.equal(1);
+                    expect(fn.firstCall.args).to.deep.equal([failures]);
+                });
             });
 
             describe('#options (reporters - single)', function () {

--- a/tests/lib/MultiReporters.test.js
+++ b/tests/lib/MultiReporters.test.js
@@ -44,6 +44,28 @@ describe('lib/MultiReporters', function () {
                 reporter = new mocha._reporter(runner, options);
             });
 
+            describe('#done (failures, fn)', function () {
+
+                var mochaDoneArgs = [2, sinon.spy()];
+
+                it('does not throw when there are no reporters available', function() {
+                    expect(reporter.done.bind(reporter, mochaDoneArgs)).not.to.throw();
+                });
+
+                it('executes the #done callback on each applicable reporter with the supplied arguments', function() {
+                    var reporterA = { done: sinon.spy() };
+                    var reporterB = {};
+                    var reporterC = { done: sinon.spy() };
+
+                    reporter._reporters = [reporterA, reporterB, reporterC];
+
+                    reporter.done.apply(reporter, mochaDoneArgs);
+
+                    expect(reporterA.done.firstCall.args).to.deep.equal(mochaDoneArgs);
+                    expect(reporterC.done.firstCall.args).to.deep.equal(mochaDoneArgs);
+                });
+            });
+
             describe('#options (reporters - single)', function () {
                 it('return reporter options: "dot"', function () {
                     expect(reporter.getReporterOptions(reporter.getOptions(options), 'dot')).to.be.deep.equal({


### PR DESCRIPTION
Addresses issue #34 

In order to ensure certain reporters produce their desired output (for example, Mochawesome's HTML report), a #done method should be provided which Mocha will call once the test suite has completed. 

Given that we're supporting multiple reporters here, we also need to ensure the invocation of the #done method is applied to each registered reporter.