### PR TITLE
Added support to load reporters from a path (absolute or relative)

### DIFF
--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -52,12 +52,10 @@ function MultiReporters(runner, options) {
                             catch (_err) {
                                 _err.message.indexOf('Cannot find module') !== -1 ? console.warn('"' + name + '" reporter not found')
                                     : console.warn('"' + name + '" reporter blew up with error:\n' + _err.stack);
-                                Reporter = null;
                             }
                         }
                         else {
                             console.warn('"' + name + '" reporter blew up with error:\n' + err.stack);
-                            Reporter = null;
                         }
                     }
                 }

--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -44,9 +44,21 @@ function MultiReporters(runner, options) {
                         Reporter = require(name);
                     }
                     catch (err) {
-                        err.message.indexOf('Cannot find module') !== -1 ?
-                            console.warn('"' + name + '" reporter not found') : console.warn('"' + name + '" reporter blew up with error:\n' + err.stack);
-                        Reporter = null;
+                        if (err.message.indexOf('Cannot find module') !== -1) {
+                            // Try to load reporters from a path (absolute or relative)
+                            try {
+                                Reporter = require(path.resolve(process.cwd(), name));
+                            }
+                            catch (_err) {
+                                _err.message.indexOf('Cannot find module') !== -1 ? console.warn('"' + name + '" reporter not found')
+                                    : console.warn('"' + name + '" reporter blew up with error:\n' + _err.stack);
+                                Reporter = null;
+                            }
+                        }
+                        else {
+                            console.warn('"' + name + '" reporter blew up with error:\n' + err.stack);
+                            Reporter = null;
+                        }
                     }
                 }
 

--- a/package.json
+++ b/package.json
@@ -17,19 +17,19 @@
   "dependencies": {
     "debug": "^2.2.0",
     "lodash": "^4.16.4",
-    "object-assign-deep": "^0.3.1",
+    "object-assign-deep": "^0.0.4",
     "root-require": "^0.3.1"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
+    "chai": "^3.5.0",
     "coveralls": "^2.11.14",
-    "eslint": "^4.7.1",
+    "eslint": "^3.9.0",
     "eslint-config-defaults": "^9.0.0",
     "jenkins-mocha": "^2.6.0",
     "mocha": "^3.1.2",
     "mocha-lcov-reporter": "^1.2.0",
     "pre-commit": "^1.1.3",
-    "sinon": "^3.3.0"
+    "sinon": "^1.17.6"
   },
   "keywords": [
     "mocha",

--- a/package.json
+++ b/package.json
@@ -17,19 +17,19 @@
   "dependencies": {
     "debug": "^2.2.0",
     "lodash": "^4.16.4",
-    "object-assign-deep": "^0.0.4",
+    "object-assign-deep": "^0.3.1",
     "root-require": "^0.3.1"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
+    "chai": "^4.1.2",
     "coveralls": "^2.11.14",
-    "eslint": "^3.9.0",
+    "eslint": "^4.7.1",
     "eslint-config-defaults": "^9.0.0",
-    "jenkins-mocha": "^2.6.0",
+    "jenkins-mocha": "^5.0.0",
     "mocha": "^3.1.2",
     "mocha-lcov-reporter": "^1.2.0",
     "pre-commit": "^1.1.3",
-    "sinon": "^1.17.6"
+    "sinon": "^3.3.0"
   },
   "keywords": [
     "mocha",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "coveralls": "^2.11.14",
     "eslint": "^4.7.1",
     "eslint-config-defaults": "^9.0.0",
-    "jenkins-mocha": "^5.0.0",
+    "jenkins-mocha": "^2.6.0",
     "mocha": "^3.1.2",
     "mocha-lcov-reporter": "^1.2.0",
     "pre-commit": "^1.1.3",

--- a/tests/custom-internal-config.json
+++ b/tests/custom-internal-config.json
@@ -1,5 +1,5 @@
 {
-    "reporterEnabled": "dot",
+    "reporterEnabled": "dot, tests/custom-internal-reporter",
 
     "xunitReporterOptions": {
         "output": "artifacts/test/custom-xunit.xml"

--- a/tests/custom-internal-reporter.js
+++ b/tests/custom-internal-reporter.js
@@ -1,0 +1,12 @@
+var mocha = require('mocha');
+var Base = mocha.reporters.Base;
+
+/**
+ * This is a project-local custom reporter which is used as a stub in tests
+ * to verify if loading reporters from a path (absolute or relative) is successful
+ */
+function CustomReporterStub(runner) {
+  Base.call(this, runner);
+}
+
+module.exports = CustomReporterStub;

--- a/tests/lib/MultiReporters.test.js
+++ b/tests/lib/MultiReporters.test.js
@@ -23,6 +23,7 @@ describe('lib/MultiReporters', function () {
     });
 
     describe('#instance', function () {
+        var mocha;
         var suite;
         var runner;
         var reporter;
@@ -30,7 +31,7 @@ describe('lib/MultiReporters', function () {
 
         describe('#internal', function () {
             beforeEach(function () {
-                var mocha = new Mocha({
+                mocha = new Mocha({
                     reporter: MultiReporters
                 });
                 suite = new Suite('#internal-multi-reporter', 'root');
@@ -135,7 +136,7 @@ describe('lib/MultiReporters', function () {
 
                 it('return custom options', function () {
                     expect(reporter.getCustomOptions(options)).to.be.deep.equal({
-                        reporterEnabled: 'dot',
+                        reporterEnabled: 'dot, tests/custom-internal-reporter',
                         xunitReporterOptions: {
                             output: 'artifacts/test/custom-xunit.xml'
                         }
@@ -144,7 +145,7 @@ describe('lib/MultiReporters', function () {
 
                 it('return resultant options by merging both default and custom options', function () {
                     expect(reporter.getOptions(options)).to.be.deep.equal({
-                        reporterEnabled: 'dot',
+                        reporterEnabled: 'dot, tests/custom-internal-reporter',
                         reporterOptions: {
                             id: 'default'
                         },
@@ -161,6 +162,24 @@ describe('lib/MultiReporters', function () {
                     });
                 });
             });
+
+            describe('#custom-internal-reporter', function () {
+                beforeEach(function() {
+                    options = {
+                        execute: true,
+                        reporterOptions: {
+                            configFile: 'tests/custom-internal-config.json'
+                        }
+                    };
+                    reporter = new mocha._reporter(runner, options);
+                });
+
+                it('return default options for "custom-internal-reporter"', function () {
+                    expect(reporter.getReporterOptions(reporter.getOptions(options), 'custom-internal-reporter')).to.be.deep.equal({
+                        id: 'default',
+                    });
+                });
+            });
         });
 
         describe('#external', function () {
@@ -173,7 +192,7 @@ describe('lib/MultiReporters', function () {
 
             describe('json', function() {
                 beforeEach(function () {
-                    var mocha = new Mocha({
+                    mocha = new Mocha({
                         reporter: MultiReporters
                     });
                     suite = new Suite('#external-multi-reporter', 'root');
@@ -196,7 +215,7 @@ describe('lib/MultiReporters', function () {
 
             describe('js', function() {
                 beforeEach(function () {
-                    var mocha = new Mocha({
+                    mocha = new Mocha({
                         reporter: MultiReporters
                     });
                     suite = new Suite('#external-multi-reporter', 'root');


### PR DESCRIPTION
@stanleyhlng
Added the possibility to load project-local custom reporters from absolute or relative path.
This fix has also been done in the mochajs framework as follow:
https://github.com/mochajs/mocha/blob/master/lib/mocha.js#L154

