### PR TITLE
Cleaning up the dependencies

### DIFF
--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -4,14 +4,14 @@ var _ = {
     get: require('lodash/get'),
     camelCase: require('lodash/camelCase'),
     size: require('lodash/size'),
-    after: require('lodash/after')
+    after: require('lodash/after'),
+    merge: require('lodash/merge')
 };
 var debug = require('debug')('mocha:reporters:MultiReporters');
 var fs = require('fs');
 var util = require('util')
 var mocha = require('mocha');
 var Base = mocha.reporters.Base;
-var objectAssignDeep = require('object-assign-deep');
 var path = require('path');
 
 function MultiReporters(runner, options) {
@@ -108,7 +108,7 @@ MultiReporters.prototype.done = function (failures, fn) {
 
 MultiReporters.prototype.getOptions = function (options) {
     debug('options', options);
-    var resultantOptions = objectAssignDeep({}, this.getDefaultOptions(), this.getCustomOptions(options));
+    var resultantOptions = _.merge({}, this.getDefaultOptions(), this.getCustomOptions(options));
     debug('options file (resultant)', resultantOptions);
     return resultantOptions;
 };
@@ -171,7 +171,7 @@ MultiReporters.prototype.getReporterOptions = function (options, name) {
     var customReporterOptions = _.get(options, [name], {});
     debug('reporter options (custom)', _name, customReporterOptions);
 
-    var resultantReporterOptions = objectAssignDeep({}, commonReporterOptions, customReporterOptions);
+    var resultantReporterOptions = _.merge({}, commonReporterOptions, customReporterOptions);
     debug('reporter options (resultant)', _name, resultantReporterOptions);
 
     return resultantReporterOptions;

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^2.2.0",
-    "lodash": "^4.16.4",
-    "root-require": "^0.3.1"
+    "lodash": "^4.16.4"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -28,6 +27,7 @@
     "mocha": "^3.1.2",
     "mocha-lcov-reporter": "^1.2.0",
     "pre-commit": "^1.1.3",
+    "root-require": "^0.3.1",
     "sinon": "^1.17.6"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "debug": "^2.2.0",
     "lodash": "^4.16.4",
-    "object-assign-deep": "^0.0.4",
     "root-require": "^0.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
* Move `root-require` to dev dependencies, as it is only used during testing
* Remove (no longer maintained) `object-assign-deep` (`lodash` has a similar method)