### PR TITLE
Upgraded debug module from 2.x to 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "debug": "^2.2.0",
+    "debug": "^3.1.0",
     "lodash": "^4.16.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR upgrades the debug module from 2.x to 3.x for the security vulnerabilities.

![image](https://user-images.githubusercontent.com/51471/33507092-b869effe-d6a7-11e7-9396-072d814e9c25.png)
