### PR TITLE
Update node.js version for the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ after_success:
 - cat artifacts/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 language: node_js
 node_js:
-- '6.1'
+- 'iojs'
+- 'node'
+- 'lts/*'
+- '8'
+- '7'
 - '6'
 - '5'
 - '4'
-- '0.12'
-- '0.11'
-- '0.10'
-- 'iojs'
 sudo: false
 deploy:
   provider: npm


### PR DESCRIPTION
This PR updates the node js supports in travis build.

https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions