### PR TITLE
Move mocha from devDependencues to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,15 @@
     "debug": "^3.1.0",
     "lodash": "^4.16.4"
   },
+  "peerDependencies": {
+    "mocha": "^3.1.2"
+  },
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.14",
     "eslint": "^3.9.0",
     "eslint-config-defaults": "^9.0.0",
     "jenkins-mocha": "^2.6.0",
-    "mocha": "^3.1.2",
     "mocha-lcov-reporter": "^1.2.0",
     "pre-commit": "^1.1.3",
     "root-require": "^0.3.1",


### PR DESCRIPTION
Fixes #50

I did this on a Windows machine but `npm run test` does not run so the pre-commit scripts did not run either.