### PR TITLE
fix: Make mocha-multi-reporters work with Mocha 6 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+node_modules
+
+.github
+artifacts
+tests
+.coveralls.yml
+.eslint*
+.gitignore
+.travis.yml
+yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,12 @@ after_success:
 - cat artifacts/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 language: node_js
 node_js:
-- 'iojs'
 - 'node'
 - 'lts/*'
 - '8'
 - '7'
 - '6'
 - '5'
-- '4'
 sudo: false
 deploy:
   provider: npm

--- a/README.md
+++ b/README.md
@@ -1,30 +1,31 @@
-mocha-multi-reporters
+cypress-multi-reporters
 ===
 
 Generate multiple mocha reports in a single mocha execution.
 
-[![npm version](https://img.shields.io/npm/v/mocha-multi-reporters.svg?style=flat-square)](https://www.npmjs.com/package/mocha-multi-reporters)
-[![StyleCI](https://styleci.io/repos/48823069/shield)](https://styleci.io/repos/48823069)
-[![Build Status](https://travis-ci.org/stanleyhlng/mocha-multi-reporters.svg)](https://travis-ci.org/stanleyhlng/mocha-multi-reporters)
-[![Coverage Status](https://coveralls.io/repos/stanleyhlng/mocha-multi-reporters/badge.svg?branch=master&service=github)](https://coveralls.io/github/stanleyhlng/mocha-multi-reporters?branch=master)
-[![Dependency Status](https://img.shields.io/david/stanleyhlng/mocha-multi-reporters.svg?style=flat-square)](https://david-dm.org/stanleyhlng/mocha-multi-reporters)
-[![devDependency Status](https://img.shields.io/david/dev/stanleyhlng/mocha-multi-reporters.svg?style=flat-square)](https://david-dm.org/stanleyhlng/mocha-multi-reporters#info=devDependencies)
+[![npm version](https://img.shields.io/npm/v/cypress-multi-reporters.svg)]
+[![npm](https://img.shields.io/npm/dm/cypress-multi-reporters.svg)
+[![Build Status](https://travis-ci.org/you54f/cypress-multi-reporters.svg)](https://travis-ci.org/you54f/cypress-multi-reporters)
+[![Coverage Status](https://coveralls.io/repos/you54f/cypress-multi-reporters/badge.svg?branch=master&service=github)](https://coveralls.io/github/you54f/cypress-multi-reporters?branch=master)
+[![Dependency Status](https://img.shields.io/david/you54f/cypress-multi-reporters.svg?style=flat-square)](https://david-dm.org/you54f/cypress-multi-reporters)
+[![devDependency Status](https://img.shields.io/david/dev/you54f/cypress-multi-reporters.svg?style=flat-square)](https://david-dm.org/stanleyhlng/cypress-multi-reporters#info=devDependencies)
+
 
 ## Install
 
 ```
-npm install mocha-multi-reporters --save-dev
+npm install cypress-multi-reporters --save-dev
 ```
 
 ## Demo
-https://github.com/stanleyhlng/mocha-multi-reporters-demo
+https://github.com/stanleyhlng/cypress-multi-reporters-demo
 
 ## Usage
 
 ### Basic
 
 ```bash
-$ ./node_modules/.bin/mocha --reporter mocha-multi-reporters
+$ ./node_modules/.bin/mocha --reporter cypress-multi-reporters
   mocha-test #1
     ✓ sample test #1.1
     ✓ sample test #1.2
@@ -57,7 +58,7 @@ $ ./node_modules/.bin/mocha --reporter mocha-multi-reporters
 ```
 
 ```bash
-$ ./node_modules/.bin/mocha --reporter mocha-multi-reporters --reporter-options configFile=config.json
+$ ./node_modules/.bin/mocha --reporter cypress-multi-reporters --reporter-options configFile=config.json
   mocha-test #1
     ✓ sample test #1.1
     ✓ sample test #1.2
@@ -149,7 +150,7 @@ $ ./node_modules/.bin/mocha --reporter mocha-multi-reporters --reporter-options 
 }
 ```
 ```bash
-$ ./node_modules/.bin/mocha --reporter mocha-multi-reporters --reporter-options configFile=config.json
+$ ./node_modules/.bin/mocha --reporter cypress-multi-reporters --reporter-options configFile=config.json
 
 1..4
 ok 1 mocha-test 1 sample test 1.1
@@ -186,7 +187,7 @@ $ npm install mocha-junit-reporter
 }
 ```
 ```bash
-$ ./node_modules/.bin/mocha --reporter mocha-multi-reporters --reporter-options configFile=config.json
+$ ./node_modules/.bin/mocha --reporter cypress-multi-reporters --reporter-options configFile=config.json
 
 1..4
 ok 1 mocha-test 1 sample test 1.1
@@ -217,11 +218,11 @@ $ cat xunit-custom.xml
 
 * When calling Mocha programmatically
 
-Note that when Mocha is called programmatically, it is passed an options object when created.  This object is usually derived from a config file that your mocha test runner reads prior to instantiation.  This is the object that must contain a key `reporter` with a value of `mocha-multi-reporters` for this plugin to be used.  You can also pass the key `reporterOptions` with a value of any of the above listed config files (including the `reporterEnabled` subkey and any other plugin configuration information.)  This removes the requirement to have an intermediate configuration file specifically for the multireporter configuration.
+Note that when Mocha is called programmatically, it is passed an options object when created.  This object is usually derived from a config file that your mocha test runner reads prior to instantiation.  This is the object that must contain a key `reporter` with a value of `cypress-multi-reporters` for this plugin to be used.  You can also pass the key `reporterOptions` with a value of any of the above listed config files (including the `reporterEnabled` subkey and any other plugin configuration information.)  This removes the requirement to have an intermediate configuration file specifically for the multireporter configuration.
 
 ```js
 var mocha = new Mocha({
-      reporter: "mocha-multi-reporters",
+      reporter: "cypress-multi-reporters",
       timeout: config.testTimeout || 60000,
       slow: config.slow || 10000,
       reporterOptions: {

--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -14,7 +14,30 @@ var mocha = require('mocha');
 var Base = mocha.reporters.Base;
 var path = require('path');
 
+var createStatsCollector;
+var mocha6plus;
+
+try {
+  var json = JSON.parse(
+    fs.readFileSync("./node_modules/mocha/package.json", "utf8")
+  );
+  version = json.version;
+  if (version >= "6") {
+    createStatsCollector = require("mocha/lib/stats-collector");
+    mocha6plus = true;
+  }
+  else {
+    mocha6plus = false;
+  }
+}
+catch (e) {
+  console.warn("Couldn't determine Mocha version");
+}
+
 function MultiReporters(runner, options) {
+    if (mocha6plus) {
+        createStatsCollector(runner);
+    }
     Base.call(this, runner);
 
     if (_.get(options, 'execute', true)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mocha-multi-reporters",
-  "version": "1.1.7",
+  "name": "cypress-multi-reporters",
+  "version": "1.1.12",
   "description": "Generate multiple mocha reports in a single mocha execution.",
   "main": "index.js",
   "scripts": {
@@ -9,9 +9,10 @@
     "test": "JENKINS_MOCHA_COVERAGE=true jenkins-mocha --timeout 5000 tests/**/*.test.js*"
   },
   "author": "Stanley Ng <stanleyhlng77-dev@yahoo.com.hk",
+  "contributor": "Yousaf Nabi <yousafn@gmail.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/stanleyhlng/mocha-multi-reporters"
+    "url": "https://github.com/you54f/cypress-multi-reporters"
   },
   "license": "MIT",
   "dependencies": {
@@ -24,11 +25,13 @@
     "eslint": "^3.9.0",
     "eslint-config-defaults": "^9.0.0",
     "jenkins-mocha": "^2.6.0",
-    "mocha": "^3.1.2",
     "mocha-lcov-reporter": "^1.2.0",
     "pre-commit": "^1.1.3",
     "root-require": "^0.3.1",
     "sinon": "^1.17.6"
+  },
+  "peerDependencies": {
+    "mocha": ">=3.1.2"
   },
   "keywords": [
     "mocha",


### PR DESCRIPTION
Mocha 6 introduced breaking changes in v6.0 specifically around reporters

https://github.com/mochajs/mocha/releases/tag/v6.0.0

the particular breaking change for reporters - https://github.com/mochajs/mocha/pull/3458


PR tracking the mocha 6 upgrade and failing CI test run

https://github.com/YOU54F/cypressio-docker-typescript/pull/15

```
TypeError: Cannot read property 'failures' of undefined
    at MochaJUnitReporter.getXml (/root/app/e2e/node_modules/mocha-junit-reporter/index.js:291:22)
    at MochaJUnitReporter.flush (/root/app/e2e/node_modules/mocha-junit-reporter/index.js:238:18)
    at MochaJUnitReporter.<anonymous> (/root/app/e2e/node_modules/mocha-junit-reporter/index.js:144:10)
    at emitOne (events.js:120:20)
    at Runner.emit (events.js:210:7)
    at Reporter.emit (/root/.cache/Cypress/3.1.3/Cypress/resources/app/packages/server/lib/reporter.js:239:55)
    at Object.server.startWebsockets.onMocha (/root/.cache/Cypress/3.1.3/Cypress/resources/app/packages/server/lib/project.js:296:22)
    at Socket.<anonymous> (/root/.cache/Cypress/3.1.3/Cypress/resources/app/packages/server/lib/socket.js:237:36)
    at emitTwo (events.js:125:13)
    at Socket.emit (events.js:213:7)
    at /root/.cache/Cypress/3.1.3/Cypress/resources/app/packages/socket/node_modules/socket.io/lib/socket.js:503:12
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)

```

I have created forks of mocha-multi-reporter and mocha-junit-reporter and applied the fix in my cypress test suite, pulling in the forked repos with fixes applied and everything is working end to end now including mochawesome reporting.

Test runs are now passing 👍 would need a major version release, as it will be a breaking change for any users with mocha versions below 6.

https://circleci.com/gh/YOU54F/cypressio-docker-typescript/95