### PR TITLE
Check reporter

### DIFF
--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -88,7 +88,7 @@ MultiReporters.prototype.done = function (failures, fn) {
     }
 
     var reportersWithDoneHandler = this._reporters.filter(function (reporter) {
-        return typeof reporter.done === 'function';
+        return reporter && (typeof reporter.done === 'function');
     });
 
     var numberOfReportersWithDoneHandler = _.size(reportersWithDoneHandler);


### PR DESCRIPTION
Sometimes I got this error because reporter is undefined.

return typeof reporter.done === 'function';
                               ^
TypeError: Cannot read property 'done' of undefined
