### PR TITLE
Pass options to reporter as reporterOption

### DIFF
--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -89,6 +89,7 @@ function MultiReporters(runner, options) {
                 if (Reporter !== null) {
                     return new Reporter(
                         runner, {
+                            reporterOption: reporterOptions,
                             reporterOptions
                         }
                     );


### PR DESCRIPTION
Some reporters (e.g. the `json` reporter) expect reporter options to be set under the `reporterOption` key and don't recognize options passed under `reporterOptions`. To ensure compatibility, this change passes in the options under both keys.