### PR TITLE
fix: support Mocha 12's class-based Base reporter

### DIFF
--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -9,7 +9,6 @@ const _ = {
 };
 const debug = require('debug')('mocha:reporters:MultiReporters');
 const fs = require('fs');
-const util = require('util');
 const mocha = require('mocha');
 const {Base} = mocha.reporters;
 const path = require('path');
@@ -36,189 +35,189 @@ catch (e) {
     console.warn('Couldn\'t determine Mocha version');
 }
 
-function MultiReporters(runner, options) {
-    // istanbul ignore else
-    if (mocha6plus) {
-        createStatsCollector(runner);
+class MultiReporters extends Base {
+    constructor(runner, options) {
+        // istanbul ignore else
+        if (mocha6plus) {
+            createStatsCollector(runner);
+        }
+        super(runner);
+
+        if (_.get(options, 'execute', true)) {
+            options = this.getOptions(options);
+
+            let enabledReporters = _.get(options, 'reporterEnabled', 'tap');
+            if (!Array.isArray(enabledReporters)) {
+                enabledReporters = enabledReporters.split(',');
+            }
+
+            this._reporters = enabledReporters.map(
+                function processReporterEnabled(name, index) {
+                    debug(name, index);
+
+                    name = name.trim();
+
+                    const reporterOptions = this.getReporterOptions(options, name);
+
+                    //
+                    // Mocha Reporters
+                    // https://github.com/mochajs/mocha/blob/master/lib/reporters/index.js
+                    //
+                    let Reporter = _.get(mocha, ['reporters', name], null);
+
+                    //
+                    // External Reporters.
+                    // Try to load reporters from process.cwd() and node_modules.
+                    //
+                    if (Reporter === null) {
+                        let originalError;
+                        try {
+                            Reporter = require(name);
+                        }
+                        catch (err) {
+                            originalError = err;
+                            const qualifiedFile = path.resolve(process.cwd(), name);
+                            try {
+                                Reporter = require(qualifiedFile);
+                            }
+                            catch (_err) {
+                                console.error(`Failed to load reporter: "${name}" or "${qualifiedFile}": ${originalError.stack}`);
+                            }
+                        }
+                    }
+
+                    if (Reporter !== null) {
+                        return new Reporter(
+                            runner, {
+                                reporterOptions
+                            }
+                        );
+                    }
+                    else {
+                        console.error('Reporter not found!', name);
+                    }
+                },
+                this
+            );
+        }
     }
-    Base.call(this, runner);
 
-    if (_.get(options, 'execute', true)) {
-        options = this.getOptions(options);
+    done(failures, fn) {
+        const numberOfReporters = _.size(this._reporters);
 
-        let enabledReporters = _.get(options, 'reporterEnabled', 'tap');
-        if (!Array.isArray(enabledReporters)) {
-            enabledReporters = enabledReporters.split(',');
+        if (numberOfReporters === 0) {
+            console.error('Unable to invoke fn(failures) - no reporters were registered');
+            return;
         }
 
-        this._reporters = enabledReporters.map(
-            function processReporterEnabled(name, index) {
-                debug(name, index);
+        const reportersWithDoneHandler = this._reporters.filter(function (reporter) {
+            return reporter && (typeof reporter.done === 'function');
+        });
 
-                name = name.trim();
+        const numberOfReportersWithDoneHandler = _.size(reportersWithDoneHandler);
 
-                const reporterOptions = this.getReporterOptions(options, name);
+        if (numberOfReportersWithDoneHandler === 0) {
+            return fn(failures);
+        }
 
-                //
-                // Mocha Reporters
-                // https://github.com/mochajs/mocha/blob/master/lib/reporters/index.js
-                //
-                let Reporter = _.get(mocha, ['reporters', name], null);
+        const done = _.after(numberOfReportersWithDoneHandler, function() {
+            fn(failures);
+        });
 
-                //
-                // External Reporters.
-                // Try to load reporters from process.cwd() and node_modules.
-                //
-                if (Reporter === null) {
-                    let originalError;
-                    try {
-                        Reporter = require(name);
-                    }
-                    catch (err) {
-                        originalError = err;
-                        const qualifiedFile = path.resolve(process.cwd(), name);
-                        try {
-                            Reporter = require(qualifiedFile);
-                        }
-                        catch (_err) {
-                            console.error(`Failed to load reporter: "${name}" or "${qualifiedFile}": ${originalError.stack}`);
-                        }
-                    }
-                }
-
-                if (Reporter !== null) {
-                    return new Reporter(
-                        runner, {
-                            reporterOptions
-                        }
-                    );
-                }
-                else {
-                    console.error('Reporter not found!', name);
-                }
-            },
-            this
-        );
-    }
-}
-
-util.inherits(MultiReporters, Base);
-
-MultiReporters.CONFIG_FILE = '../config.json';
-
-MultiReporters.prototype.done = function (failures, fn) {
-    const numberOfReporters = _.size(this._reporters);
-
-    if (numberOfReporters === 0) {
-        console.error('Unable to invoke fn(failures) - no reporters were registered');
-        return;
+        reportersWithDoneHandler.forEach(function(reporter) {
+            reporter.done(failures, done);
+        });
     }
 
-    const reportersWithDoneHandler = this._reporters.filter(function (reporter) {
-        return reporter && (typeof reporter.done === 'function');
-    });
+    getOptions(options) {
+        debug('options', options);
 
-    const numberOfReportersWithDoneHandler = _.size(reportersWithDoneHandler);
+        const mmrOutput = _.get(options, 'reporterOptions.mmrOutput') || _.get(options, 'reporterOptions.cmrOutput');
+        const resultantOptions = _.merge({}, this.getDefaultOptions(), this.getCustomOptions(options), mmrOutput ? {mmrOutput} : null);
 
-    if (numberOfReportersWithDoneHandler === 0) {
-        return fn(failures);
+        debug('options file (resultant)', resultantOptions);
+        return resultantOptions;
     }
 
-    const done = _.after(numberOfReportersWithDoneHandler, function() {
-        fn(failures);
-    });
-
-    reportersWithDoneHandler.forEach(function(reporter) {
-        reporter.done(failures, done);
-    });
-};
-
-MultiReporters.prototype.getOptions = function (options) {
-    debug('options', options);
-
-    const mmrOutput = _.get(options, 'reporterOptions.mmrOutput') || _.get(options, 'reporterOptions.cmrOutput');
-    const resultantOptions = _.merge({}, this.getDefaultOptions(), this.getCustomOptions(options), mmrOutput ? {mmrOutput} : null);
-
-    debug('options file (resultant)', resultantOptions);
-    return resultantOptions;
-};
-
-MultiReporters.prototype.getCustomOptions = function (options) {
-    let customOptionsFile = _.get(options, 'reporterOptions.configFile');
-    debug('options file (custom)', customOptionsFile);
-
-    let customOptions;
-    if (customOptionsFile) {
-        customOptionsFile = path.resolve(customOptionsFile);
+    getCustomOptions(options) {
+        let customOptionsFile = _.get(options, 'reporterOptions.configFile');
         debug('options file (custom)', customOptionsFile);
 
-        try {
-            if ('.js' === path.extname(customOptionsFile)) {
-                customOptions = require(customOptionsFile);
-            }
-            else {
-                customOptions = JSON.parse(fs.readFileSync(customOptionsFile).toString());
-            }
+        let customOptions;
+        if (customOptionsFile) {
+            customOptionsFile = path.resolve(customOptionsFile);
+            debug('options file (custom)', customOptionsFile);
 
-            debug('options (custom)', customOptions);
+            try {
+                if ('.js' === path.extname(customOptionsFile)) {
+                    customOptions = require(customOptionsFile);
+                }
+                else {
+                    customOptions = JSON.parse(fs.readFileSync(customOptionsFile).toString());
+                }
+
+                debug('options (custom)', customOptions);
+            }
+            catch (e) {
+                console.error(e);
+                throw e;
+            }
+        }
+        else {
+            customOptions = _.get(options, 'reporterOptions');
+        }
+
+        return customOptions;
+    }
+
+    getDefaultOptions() {
+        const defaultOptionsFile = require.resolve(MultiReporters.CONFIG_FILE);
+        debug('options file (default)', defaultOptionsFile);
+
+        let defaultOptions = fs.readFileSync(defaultOptionsFile).toString();
+        debug('options (default)', defaultOptions);
+
+        try {
+            defaultOptions = JSON.parse(defaultOptions);
         }
         catch (e) {
             console.error(e);
             throw e;
         }
-    }
-    else {
-        customOptions = _.get(options, 'reporterOptions');
-    }
 
-    return customOptions;
-};
-
-MultiReporters.prototype.getDefaultOptions = function () {
-    const defaultOptionsFile = require.resolve(MultiReporters.CONFIG_FILE);
-    debug('options file (default)', defaultOptionsFile);
-
-    let defaultOptions = fs.readFileSync(defaultOptionsFile).toString();
-    debug('options (default)', defaultOptions);
-
-    try {
-        defaultOptions = JSON.parse(defaultOptions);
-    }
-    catch (e) {
-        console.error(e);
-        throw e;
+        return defaultOptions;
     }
 
-    return defaultOptions;
-};
+    getReporterOptions(options, name) {
+        const _name = name;
+        const commonReporterOptions = _.get(options, 'reporterOptions', {});
+        debug('reporter options (common)', _name, commonReporterOptions);
 
-MultiReporters.prototype.getReporterOptions = function (options, name) {
-    const _name = name;
-    const commonReporterOptions = _.get(options, 'reporterOptions', {});
-    debug('reporter options (common)', _name, commonReporterOptions);
+        name = [_.camelCase(name), 'ReporterOptions'].join('');
+        const customReporterOptions = _.get(options, [name], {});
+        debug('reporter options (custom)', _name, customReporterOptions);
 
-    name = [_.camelCase(name), 'ReporterOptions'].join('');
-    const customReporterOptions = _.get(options, [name], {});
-    debug('reporter options (custom)', _name, customReporterOptions);
+        const resultantReporterOptions = _.merge({}, commonReporterOptions, customReporterOptions);
+        debug('reporter options (resultant)', _name, resultantReporterOptions);
 
-    const resultantReporterOptions = _.merge({}, commonReporterOptions, customReporterOptions);
-    debug('reporter options (resultant)', _name, resultantReporterOptions);
-
-    let mmrOutput = _.get(options, 'mmrOutput') || _.get(options, 'cmrOutput');
-    if (mmrOutput) {
-        if (!Array.isArray(mmrOutput)) {
-            mmrOutput = mmrOutput.split(':').map((mmrOutputReporter) => {
-                return mmrOutputReporter.split('+');
+        let mmrOutput = _.get(options, 'mmrOutput') || _.get(options, 'cmrOutput');
+        if (mmrOutput) {
+            if (!Array.isArray(mmrOutput)) {
+                mmrOutput = mmrOutput.split(':').map((mmrOutputReporter) => {
+                    return mmrOutputReporter.split('+');
+                });
+            }
+            mmrOutput.forEach(([targetName, prop, output]) => {
+                if (resultantReporterOptions[prop] && _name === targetName) {
+                    resultantReporterOptions[prop] = resultantReporterOptions[prop].replace(/\{id\}/gu, output);
+                }
             });
         }
-        mmrOutput.forEach(([targetName, prop, output]) => {
-            if (resultantReporterOptions[prop] && _name === targetName) {
-                resultantReporterOptions[prop] = resultantReporterOptions[prop].replace(/\{id\}/gu, output);
-            }
-        });
-    }
 
-    return resultantReporterOptions;
-};
+        return resultantReporterOptions;
+    }
+}
+
+MultiReporters.CONFIG_FILE = '../config.json';
 
 module.exports = MultiReporters;

--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -86,6 +86,14 @@ class MultiReporters extends Base {
                         }
                     }
 
+                    //
+                    // Unwrap ESM default exports (e.g. `export default class Reporter {}`),
+                    // which require() surfaces as a namespace object rather than the class itself.
+                    //
+                    if (Reporter && Reporter.default) {
+                        Reporter = Reporter.default;
+                    }
+
                     if (Reporter !== null) {
                         return new Reporter(
                             runner, {

--- a/tests/custom-esm-default-config.json
+++ b/tests/custom-esm-default-config.json
@@ -1,0 +1,3 @@
+{
+    "reporterEnabled": "tests/custom-esm-default-reporter"
+}

--- a/tests/custom-esm-default-reporter.js
+++ b/tests/custom-esm-default-reporter.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const mocha = require('mocha');
+const {Base} = mocha.reporters;
+
+/**
+ * This mimics the CJS interop shape Node produces for a reporter authored as
+ * `export default class Reporter extends Base {}` and compiled/loaded via require():
+ * a namespace object with a `default` property, rather than the class itself.
+ */
+class EsmReporterStub extends Base {
+    constructor(runner) {
+        super(runner);
+    }
+}
+
+module.exports = {
+    __esModule: true,
+    default: EsmReporterStub
+};
+
+module.exports.EsmReporterStub = EsmReporterStub;

--- a/tests/lib/MultiReporters.test.js
+++ b/tests/lib/MultiReporters.test.js
@@ -199,6 +199,25 @@ describe('lib/MultiReporters', function () {
                 });
             });
 
+            describe('#custom-esm-default-reporter', function () {
+                const {EsmReporterStub} = require('../custom-esm-default-reporter');
+
+                beforeEach(function() {
+                    options = {
+                        execute: true,
+                        reporterOptions: {
+                            configFile: 'tests/custom-esm-default-config.json'
+                        }
+                    };
+                    reporter = new mocha._reporter(runner, options);
+                });
+
+                it('unwraps the ESM default export and constructs the reporter', function () {
+                    expect(reporter._reporters).to.have.lengthOf(1);
+                    expect(reporter._reporters[0]).to.be.instanceof(EsmReporterStub);
+                });
+            });
+
             describe('#custom-erring-internal-reporter', function () {
                 beforeEach(function() {
                     options = {


### PR DESCRIPTION
## Summary
- Mocha 12 converted the `Base` reporter from a plain constructor function to an ES6 `class`. The old `util.inherits(MultiReporters, Base)` + `Base.call(this, runner)` pattern breaks on this with `TypeError: Class constructor Base cannot be invoked without 'new'`.
- Rewrote `lib/MultiReporters.js` as `class MultiReporters extends Base`, calling `super(runner)` instead. This works whether `Base` is a plain function (Mocha < 12) or an ES6 class (Mocha 12+), since `class X extends F` / `super()` is valid either way.
- No behavior changes — same options-merging, reporter-resolution, and `done()` fan-out logic as before.

Fixes #112
Fixes #111

## Test plan
- [x] `npm test` — all 23 existing tests pass, 100% coverage maintained
- [x] `eslint .` clean
- [x] Reproduced the exact crash from #112 against real `mocha@12.0.0` with the old code (identical stack trace: `MultiReporters.js:44:10` → `mocha.cjs:1001:18` → `run-helpers.cjs:175:16` → `run.cjs:143:5`)
- [x] Confirmed the fixed code runs cleanly against `mocha@12.0.0` with the same reporter setup
- [x] Confirmed the fixed code still passes the full suite against the pinned `mocha@8.2.0` (function-style `Base`)