### PR TITLE
chore: pin publish registry to registry.npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "homepage": "https://github.com/stanleyhlng/mocha-multi-reporters",
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
     "debug": "^4.1.1",


### PR DESCRIPTION
## Summary
Local npm on this machine defaults to an internal Artifactory proxy registry rather than the public npm registry. Without this, `npm publish` would target the wrong registry. Pins `publishConfig.registry` explicitly for this package so publishing always goes to `registry.npmjs.org`, regardless of the local default.