### PR TITLE
chore: exclude Claude Code artifacts from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -24,3 +24,8 @@ mocha-multi-reporters*.tgz
 
 renovate.json
 .ncurc.js
+
+.claude
+.node-version
+CLAUDE.md
+PLAN.md


### PR DESCRIPTION
## Summary
A dry-run publish (`npm publish --dry-run`) revealed the tarball would include `.claude/`, `.node-version`, and `CLAUDE.md` — none of which are covered by the existing `.npmignore`, since npm's default packing isn't restricted to git-tracked files. In particular, `.claude/worktrees/...` pulled in a full duplicate copy of the package.

Adds `.claude`, `.node-version`, `CLAUDE.md`, `PLAN.md` to `.npmignore`.

## Test plan
- [x] `npm publish --dry-run` before: 18 files, 56.6 kB unpacked, includes `.claude/worktrees/...`
- [x] `npm publish --dry-run` after: 7 files, 26.1 kB unpacked, matches the shape of the published `1.5.1` package (`CHANGELOG.md`, `LICENSE`, `README.md`, `config.json`, `index.js`, `lib/MultiReporters.js`, `package.json`)